### PR TITLE
Implement shortcut for menu items

### DIFF
--- a/codememo/app.py
+++ b/codememo/app.py
@@ -12,6 +12,7 @@ from .components import (
 )
 from .config import AppConfig, AppHistory
 from .interanl import GlobalState
+from .shortcuts import ShortcutRegistry, PygletIOWrapper
 
 # There is an issue of managing state of keys in `imgui._IO`, so that we used
 # a patched version of facilities which are originally provided in
@@ -33,6 +34,8 @@ class Application(object):
         imgui.create_context()
         self.imgui_impl = create_renderer(self.window)
 
+        self.shortcuts_registry = ShortcutRegistry(PygletIOWrapper(self.imgui_impl.io))
+
         self.imgui_components = []
         self.init_components()
         self.init_draw_process()
@@ -48,6 +51,7 @@ class Application(object):
     def init_draw_process(self):
         def update(dt):
             imgui.new_frame()
+            self.shortcuts_registry.poll()
             try:
                 for component in self.imgui_components:
                     while self._internal_state.error_occured:
@@ -56,6 +60,7 @@ class Application(object):
                     component.render()
             except Exception as ex:
                 self.dump_data(ex)
+            self.shortcuts_registry.clear()
 
         @self.window.event
         def on_draw():

--- a/codememo/components.py
+++ b/codememo/components.py
@@ -89,11 +89,13 @@ class MenuBar(ImguiComponent):
             self.app.history.write()
 
     def handle_shortcuts(self):
-        if not self.app.shortcuts_registry.has_triggered_shortcuts:
+        action_name = self.app.shortcuts_registry.triggered_shortcut
+        if action_name is None:
             return
-        action_name = self.app.shortcuts_registry.triggered_shortcuts.pop()
-        action = getattr(self, f'_menu_file__{action_name}')
-        action(triggered_by_shortcut=True)
+
+        action = getattr(self, f'_menu_file__{action_name}', None)
+        if action:
+            action(triggered_by_shortcut=True)
 
     def render(self):
         if imgui.begin_main_menu_bar():

--- a/codememo/components.py
+++ b/codememo/components.py
@@ -1048,6 +1048,14 @@ class CodeNodeViewer(ImguiComponent):
             self.handle_event__create_node
         )
 
+        # TODO: This is currently a workaround to handle local shortcuts for those
+        # widgets that may exist multiple instances simultaneously. This approach
+        # should be improved in the future.
+        if 'save' not in self.app.shortcuts_registry.registry:
+            self.app.shortcuts_registry.register('save', ['ctrl', 's'])
+        if 'save_as' not in self.app.shortcuts_registry.registry:
+            self.app.shortcuts_registry.register('save_as', ['ctrl', 'shift', 's'])
+
         self.init_nodes_and_links()
 
     @classmethod
@@ -1200,19 +1208,32 @@ class CodeNodeViewer(ImguiComponent):
         imgui.pop_item_width()
         imgui.end_child()
 
-    def handle_menu_item_save(self):
-        clicked, selected = imgui.menu_item('Save', 'Ctrl+S')
+    def handle_shortcuts(self):
+        action_name = self.app.shortcuts_registry.triggered_shortcut
+        if action_name is None:
+            return
 
-        if clicked:
+        action = getattr(self, f'handle_menu_item_{action_name}', None)
+        # TODO: action cannot be triggered if focus is at canvas or node list
+        if action and imgui.is_window_focused():
+            action(triggered_by_shortcut=True)
+
+    def handle_menu_item_save(self, triggered_by_shortcut=False):
+        clicked = False
+        if not triggered_by_shortcut:
+            clicked = imgui.menu_item('Save', 'Ctrl+S')[0]
+        if clicked or triggered_by_shortcut:
             if self.fn_src is not None:
                 self.save_data(self.fn_src)
             else:
                 # This viewer is opened from scratch, so that it's `fn_src` is None
                 self.file_dialog = SaveFileDialog(self.app, self.save_data)
 
-    def handle_menu_item_save_as(self):
-        clicked, selected = imgui.menu_item('Save as')
-        if clicked:
+    def handle_menu_item_save_as(self, triggered_by_shortcut=False):
+        clicked = False
+        if not triggered_by_shortcut:
+            clicked = imgui.menu_item('Save as')[0]
+        if clicked or triggered_by_shortcut:
             self.file_dialog = SaveFileDialog(self.app, self.save_data)
 
     def handle_menu_item_close(self):
@@ -1522,6 +1543,7 @@ class CodeNodeViewer(ImguiComponent):
         imgui.set_window_size(600, 400)
         self.handle_state()
         self.handle_file_dialog()
+        self.handle_shortcuts()
         self.display_menu_bar()
         self.draw_node_list()
         imgui.same_line()

--- a/codememo/shortcuts.py
+++ b/codememo/shortcuts.py
@@ -1,0 +1,101 @@
+__all__ = ['IOWrapper', 'PygletIOWrapper', 'ShortcutRegistry']
+
+
+class IOWrapper(object):
+    def __init__(self, io):
+        self.io = io
+
+    def is_key_pressed(self, key):
+        raise NotImplementedError
+
+
+class PygletIOWrapper(IOWrapper):
+    def __init__(self, io):
+        super(PygletIOWrapper, self).__init__(io)
+
+    def is_key_pressed(self, key):
+        key = key.lower()
+        if key in ['ctrl', 'super', 'alt', 'shift']:
+            return getattr(self.io, f'key_{key.lower()}')
+        else:
+            return self.io.keys_down[ord(key)]
+
+
+class ShortcutRegistry(object):
+    def __init__(self, io):
+        if not isinstance(io, IOWrapper):
+            raise TypeError(f'`io` should be an instance of {IOWrapper}')
+        self.io = io
+        self.registry = {}
+
+        # used to store name of triggered shortcuts
+        self.triggered_shortcuts = set()
+        # used to store name of edge-triggered shortcuts
+        self.edge_triggered_shortcuts = set()
+        # used to store name of edge-triggered shortcuts that have been triggered
+        self.prev_edge_triggered_shortcuts = set()
+
+    @property
+    def has_triggered_shortcuts(self):
+        return len(self.triggered_shortcuts) != 0
+
+    def poll(self):
+        """Iterate all registered shortcuts and check whether they are triggered."""
+        for name in self.registry:
+            if self.is_triggered(name):
+                if name in self.edge_triggered_shortcuts & self.prev_edge_triggered_shortcuts:
+                    # it's an edge-triggered shortcut and it has been triggered
+                    continue
+                else:
+                    # it's not an edge-triggered shortcut, so it can be triggered repeatedly
+                    self.triggered_shortcuts.add(name)
+            else:
+                # reset cache for edge-triggered shortcut
+                if name in self.edge_triggered_shortcuts & self.prev_edge_triggered_shortcuts:
+                    self.prev_edge_triggered_shortcuts.remove(name)
+
+    def clear(self):
+        for name in self.registry:
+            # If there is any edge-triggered shortcut was triggered, store them into
+            # `prev_edge_triggered_shortcuts` to avoid them being triggered repeatedly.
+            if name in self.edge_triggered_shortcuts & self.triggered_shortcuts:
+                self.triggered_shortcuts.remove(name)
+                self.prev_edge_triggered_shortcuts.add(name)
+        self.triggered_shortcuts.clear()
+
+    def register(self, name, key_bindings, is_edge_triggered=True):
+        """Register shortcut.
+
+        Parameters
+        ----------
+        name : str
+            Name of shortcut.
+        key_bindings : list of str
+            Combination of keys for shortcut.
+        is_edge_triggered : bool, optional
+            If true, this shortcut can only be triggered when keys are pressed down,
+            and it won't be triggered repeatedly when keys are hold.
+        """
+        if name in self.registry:
+            raise ValueError(f'shortcut for `{name}` has already been registered.')
+        if not isinstance(key_bindings, list):
+            raise TypeError(f'`key_bindings` should be a combination of keys (string)')
+        key_bindings = [v.lower() for v in key_bindings]
+        if len(set(key_bindings)) < len(key_bindings):
+            raise ValueError(f'duplicate keys detected in `key_bindings`')
+
+        self.registry.update({name: key_bindings})
+        if is_edge_triggered:
+            self.edge_triggered_shortcuts.add(name)
+
+    def unregister(self, name):
+        if name not in self.registry:
+            raise ValueError(f'shortcut for `{name}` has not yet been registered.')
+        self.registry.remove(name)
+        if name in self.edge_triggered_shortcuts:
+            self.edge_triggered_shortcuts.remove(name)
+
+    def is_triggered(self, name):
+        if name not in self.registry:
+            raise ValueError(f'shortcut for `{name}` has not yet been registered.')
+        return all([self.io.is_key_pressed(k) for k in self.registry[name]])


### PR DESCRIPTION
Because shortcut API has not been implemented in `imgui`, passed `shortcut` argument in `pyimgui.imgui.menu_item()` is currently just a display option (see also issue 456 in `ocornut/imgui`).

But since the IO part is fully controlled by the integrated backend of `imgui` (for instance, we are using `pyglet`), we can actually implement a substitute before the Shortcut API in `imgui` being implemented.

The idea of our approach for this topic is simple but it relies on our current application architecture. Here is a workflow of it (see also `update()` in `Application.init_draw_process()`):
1. When there is a new frame created, we poll all key combinations of registered shortcuts, and cache state of triggered shortcut.
2. During the process of rendering other imgui components, every component can access a registry for shortcut attached under the instance of the main application, and check whether their registered shortcuts have been triggered.
3. At the end of the process of rendering other imgui components, cached state of triggered shortcuts will be cleared from registry.

But there are a few things worth noting:
- There will be only one shortcut able to be triggered at a time. This is sensible, but we cannot expect whether there will be some speical cases in the future. See also the following code:
    https://github.com/NaleRaphael/codememo/blob/755edd1abcc6dad6a7c9ba3aaf17569ebb2f99ec/codememo/shortcuts.py#L54-L60
- [ ] Approach of local shortcut registration for those widgets that there can be multiple instances existing simutaneously is not well-handled, we may need to figure out a better solution for it. See also commit 755edd1.
- [ ] In commit f637efe, though we handled key states for ASCII characters, we haven't found a stable solution to test it.