### PR TITLE
Fix installation issue in virtual environment on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo apt-get install graphviz
 
 install:
-  - pip install -v .[full]
+  - pip install .[full]
   - pip install -r requirements_test.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo apt-get install graphviz
 
 install:
-  - pip install .[full]
+  - pip install -v .[full]
   - pip install -r requirements_test.txt
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ from setuptools import setup, find_packages
 # Method `site.getsitepackages()` won't work with `virtualenv`, see also:
 # https://github.com/pypa/virtualenv/issues/737
 if not hasattr(site, 'getsitepackages'):
-    from distutils.sysconfig import get_python_lib
-    getsitepackages = get_python_lib
+    def getsitepackages():
+        import pip
+        return [str(Path(pip.__path__).parent.absolute())]
 else:
     getsitepackages = site.getsitepackages
 

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,6 @@ def prepare_data_files():
             path_map[rel_parent].append(rel_path)
 
     # Prefix keys in `path_map` with "lib/site-packages" (depends on OS)
-    print(Path(getsitepackages()[0]).absolute())
     prefix = Path(getsitepackages()[0]).relative_to(sys.prefix)
     path_map = {str(prefix.joinpath(k)): v for k, v in path_map.items()}
 

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ def prepare_data_files():
             path_map[rel_parent].append(rel_path)
 
     # Prefix keys in `path_map` with "lib/site-packages" (depends on OS)
+    print(Path(getsitepackages()[0]).absolute())
     prefix = Path(getsitepackages()[0]).relative_to(sys.prefix)
     path_map = {str(prefix.joinpath(k)): v for k, v in path_map.items()}
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 if not hasattr(site, 'getsitepackages'):
     def getsitepackages():
         import pip
-        return [str(Path(pip.__path__).parent.absolute())]
+        return [str(Path(pip.__path__[0]).absolute())]
 else:
     getsitepackages = site.getsitepackages
 


### PR DESCRIPTION
`site.getsitepackages()` does not work in virtualenv on Travis CI, so that we get the path of site-package from `pip` package instead.

According to [this post](https://travis-ci.community/t/python-site-py-on-python-images-is-other-than-standard/7264/5), it seems this issue has been solved in `virtualenv-20.0.4`, but it still failed now. Since we cannot update `virtualenv` through ".travis.yml", we can only adopt this workaround currently.